### PR TITLE
Basic Player Mirroring

### DIFF
--- a/mirror/src/main.rs
+++ b/mirror/src/main.rs
@@ -1,29 +1,21 @@
 #![allow(unused)]
+
 use std::net::UdpSocket;
 
-//
-// fn print_type_of<T>(_: &T) {
-//     println!("{}", std::any::type_name::<T>())
-// }
-
-fn main() -> std::io::Result<()> {
+fn main() {
 	{
 		let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
 		// Receives a single datagram message on the socket. If `buf` is too small to hold
 		// the message, it will be cut off.
+
 		loop{
 			let mut buf = [0; 4];
-			let (amt, src) = socket.recv_from(&mut buf)?;
-			let x = f32::from_ne_bytes(buf);
-			let (amt, src) = socket.recv_from(&mut buf)?;
-			let y = f32::from_ne_bytes(buf);
+			let (amt, src) = socket.recv_from(&mut buf).unwrap();
+			let x = f32::from_le_bytes(buf);
+			let (amt, src) = socket.recv_from(&mut buf).unwrap();
+			let y = f32::from_le_bytes(buf);
 			println!("{:?} {:?}", x, y);
 		}
 
-		// Redeclare `buf` as slice of the received data and send reverse data back to origin.
-		// let buf = &mut buf[..amt];
-		// buf.reverse();
-		// socket.send_to(buf, &src)?;
 	} // the socket is closed here
-	Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 extern crate sdl2;
 
+use std::env;
+
 mod credits;
 mod game;
 mod player;
@@ -27,18 +29,11 @@ fn main() {
 		.map_err(|e| e.to_string())
 		.unwrap();
 
-	// current_scene lets the game know which section is running
-	// options: mainmenu, game, credits
-	let current_scene = "mainmenu";
+	let args: Vec<String> = env::args().collect();
+	let mut mode = networking::NetworkingMode::Send;
+	if args.len() == 2 && &args[1] == "mirror" {
+		mode = networking::NetworkingMode::Receive;
+	}
 
-	if current_scene == "mainmenu" {
-		//main menu code goes here
-		menu::show_menu(wincan, event_pump, mouse);
-	} else if current_scene == "game" {
-		//game code goes here
-		game::show_game(wincan, event_pump, mouse, networking::networking::NetworkingMode::Send).ok();
-	}
-	else if current_scene == "credits" {
-		credits::show_credits(wincan);
-	}
+	menu::show_menu(wincan, event_pump, mouse, mode);
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -6,15 +6,13 @@ use sdl2::mouse::MouseUtil;
 use std::thread;
 
 use crate::game::show_game;
-use crate::networking::networking::NetworkingMode;
+use crate::networking::NetworkingMode;
 
-pub(crate) fn show_menu(mut wincan: WindowCanvas, mut event_pump: sdl2::EventPump, mouse: MouseUtil)
+pub(crate) fn show_menu(mut wincan: WindowCanvas, mut event_pump: sdl2::EventPump, mouse: MouseUtil, network_mode: NetworkingMode)
 {
     let texture_creator = wincan.texture_creator();
 
     let start = texture_creator.load_texture("assets/single_assets/menu.png").unwrap();
-
-    let mut network_mode: NetworkingMode = NetworkingMode::Send;
 
     wincan.copy(&start, None, None).ok();
     wincan.present();
@@ -23,37 +21,22 @@ pub(crate) fn show_menu(mut wincan: WindowCanvas, mut event_pump: sdl2::EventPum
         for event in event_pump.poll_iter() {
             match event {
                 Event::Quit{..} | Event::KeyDown{keycode: Some(Keycode::Escape), ..} => break 'menuloop,
-                /*
-                Event::KeyDown{keycode: Some(Keycode::M), ..} => {
-                    network_mode = NetworkingMode::Recieve;
-                    break 'menuloop;
-                }
-                */
                 Event::KeyDown{keycode: Some(k), ..} => {
                     match k {
-                        Keycode::M => {
-                            network_mode = NetworkingMode::Recieve;
-                            break 'menuloop;
-                        }
+                        // Keycode::M => {
+                        //     network_mode = NetworkingMode::Receive;
+                        //     break 'menuloop
+                        // }
                         _ => break 'menuloop,
                     }
                 }
                 _ => {},
             }
-
-
         }
-        /*let keystate: HashSet<Keycode> = core.event_pump.keyboard_state().pressed_scancodes().filter_map(Keycode::from_scancode).collect();
-        if keystate.contains(&Keycode::Space) {
-            show_game(core);
-            // core.wincan.clear();
-            // current_scene = "game"
-        } */
     }
-    match &network_mode {
-        NetworkingMode::Send => print!("SENDING"),
-        NetworkingMode::Recieve => print!("RECIEVING"),
-    }
-
+    // match &network_mode {
+    //     NetworkingMode::Send => print!("SENDING"),
+    //     NetworkingMode::Receive => print!("RECEIVING"),
+    // }
     show_game(wincan, event_pump, mouse, network_mode).ok();
 }

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -1,10 +1,60 @@
-pub mod networking {
+use std::borrow::Borrow;
+use std::net::UdpSocket;
 
-    pub enum NetworkingMode {
-        Send,
-        Recieve,
+use crate::player::player::Player;
+
+#[derive(Clone, Copy)]
+pub(crate) enum NetworkingMode {
+    Send,
+    Receive,
+}
+
+pub(crate) fn get_sending_socket() -> UdpSocket {
+    get_socket("127.0.0.1:34255")
+}
+
+pub(crate) fn get_receiving_socket() -> UdpSocket {
+    get_socket("127.0.0.1:34254")
+}
+
+fn get_socket(address: &str) -> UdpSocket {
+    UdpSocket::bind(address).expect("couldn't bind to address")
+}
+
+// refactor to make safe -- return result
+fn get_player_position_and_flip(socket: &mut UdpSocket) -> (f32, f32) {
+    let mut buf = [0; 4];
+    let (amt, src) = socket.recv_from(&mut buf).unwrap();
+    let x = f32::from_le_bytes(buf);
+    let (amt, src) = socket.recv_from(&mut buf).unwrap();
+    let y = f32::from_le_bytes(buf);
+    // TODO: add getting flip
+    (x,y)
+}
+
+// pub(crate) fn do_networking(player: &mut Player, socket: &mut UdpSocket, mode: NetworkingMode) {
+//     match mode {
+//         Send => {
+//             send_data(player, socket);
+//         }
+//         Receive => {
+//             receive_data(socket);
+//         }
+//     }
+// }
+
+pub(crate) fn receive_data(socket: &mut UdpSocket) -> (f32, f32) {
+    get_player_position_and_flip(socket)
+}
+
+pub(crate) fn send_data(player: &mut Player, socket: &UdpSocket, flip: bool) {
+    socket.send(player.physics.x().to_ne_bytes().borrow());
+    socket.send(player.physics.y().to_ne_bytes().borrow());
+}
+
+pub(crate) fn get_socket_for_networking(mode: NetworkingMode) -> UdpSocket {
+    match mode {
+        Send => get_sending_socket(),
+        Receive => get_receiving_socket(),
     }
-
-} 
-
-
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -13,8 +13,8 @@ pub mod player {
     }
 
     impl Player<'_> {
-        pub fn new<'a>(_sheet: Texture<'a>, _physics: PhysicsController, _collider: RectCollider, _anim: AnimController, _portal: PortalController)
-            -> Player<'a>
+        pub fn new(_sheet: Texture, _physics: PhysicsController, _collider: RectCollider, _anim: AnimController, _portal: PortalController)
+                   -> Player
         {
             Player {
                 sprite_sheet: _sheet,


### PR DESCRIPTION
- portal basics
- wand moving
- portal creation
- collider detection
- cleaning up warnings
- fixed rotation bug
- skeleton code
- main menu image change
- player coords are converted from bytes to floats in mirror.
- general physics fixes
- Portal Mechanic with strange error
- Implemented Portal Teleportation
- Implemented Teleportation
- Added a networking mode enum
- Basic player mirroring successful
